### PR TITLE
Added TraceFind

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Recon-ng](https://github.com/lanmaster53/recon-ng) – Web reconnaissance framework written in Python.
 - [Metagoofil](https://github.com/laramies/metagoofil) – Extract metadata from public documents.
 - [GHunt](https://github.com/mxrch/GHunt) – Investigate Google accounts and services using public info.
+- [TraceFind](https://tracefind.info) – Uncover the Truth Behind Any Email — Instantly
+
 
 ## Training & Guides
 


### PR DESCRIPTION
Hi there,

I’m reaching out regarding TraceFind (https://tracefind.info/). I’d love to have TraceFind added to your OSINT tools repository.

I’ve also added a free tier to the platform, so people can try it out without having to pay. If needed, I’d also be happy to provide some free credits for testing or evaluation. This isnt trying to be self-advertisement I just think it would be a great addition to your project and may be beneficial to other users and their investigation. Let me know if thats okay or not.

TraceFind is an OSINT tool focused on finding digital footprints linked to email addresses, including associated accounts, usernames, and other publicly available information.

Thanks for taking a look at the pull request, and feel free to reach out if you need anything from me.

Best,
Elias